### PR TITLE
Mdfcc dev

### DIFF
--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -144,6 +144,12 @@ class MDFConnectClient:
         These arguments should be valid DataCite, as listed in the MDF Connect documentation.
         This is completely optional.
         """
+        if not title and not authors:
+            raise TypeError("'title' and 'authors' are required arguments.")
+        if not title:
+            raise TypeError("'title' is a required arguments.")
+        if not authors:
+            raise TypeError("'authors' is a required argument.")
         # titles
         if not isinstance(title, list):
             title = [title]
@@ -636,7 +642,8 @@ class MDFConnectClient:
         return {
             "source_id": source_id,
             "success": error is None,
-            "error": error
+            "error": error,
+            "status_code": res.status_code
         }
 
     def check_status(self, source_id=None, raw=False):

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -660,7 +660,7 @@ class MDFConnectClient:
                     **Default:** ``False``
 
         Returns:
-            If ``raw`` is ``True``, *dict*: The full status.
+            If ``raw`` is ``True``, *dict*: The full status result.
         """
         if not source_id and not self.source_id:
             print("Error: No dataset submitted")
@@ -678,17 +678,24 @@ class MDFConnectClient:
 
         try:
             json_res = res.json()
-        except Exception:
-            if res.status_code < 300:
+        except Exception as e:
+            if raw:
+                return {
+                    "success": False,
+                    "error": "{}: {}".format(e, res.content),
+                    "status_code": res.status_code
+                }
+            elif res.status_code < 300:
                 print("Error decoding {} response: {}".format(res.status_code, res.content))
             else:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
-            if res.status_code >= 300:
+            if raw:
+                json_res["status_code"] = res.status_code
+                return json_res
+            elif res.status_code >= 300:
                 print("Error {} fetching status: {}".format(res.status_code, json_res))
-            elif raw:
-                return json_res["status"]
             else:
                 print("\n", json_res["status"]["status_message"], "\nThis submission is ",
                       ("active." if json_res["status"]["active"] else "inactive."), sep="")
@@ -719,7 +726,7 @@ class MDFConnectClient:
                     **Default:** ``None``, the only valid value for non-admins.
 
         Returns:
-            if raw is ``True``, *list of dict*: The full statuses.
+            if raw is ``True``, *dict*: The full status results.
         """
         headers = {}
         self.__authorizer.set_authorization_header(headers)
@@ -734,17 +741,26 @@ class MDFConnectClient:
 
         try:
             json_res = res.json()
-        except Exception:
-            if res.status_code < 300:
+        except Exception as e:
+            if raw:
+                return {
+                    "success": False,
+                    "error": "{}: {}".format(e, res.content),
+                    "status_code": res.status_code
+                }
+            elif res.status_code < 300:
                 print("Error decoding {} response: {}".format(res.status_code, res.content))
             else:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
-            if res.status_code >= 300:
+            if raw:
+                json_res["status_code"] = res.status_code
+                json_res["submissions"] = [sub for sub in json_res["submissions"]
+                                           if (not active or sub["active"])]
+                return json_res
+            elif res.status_code >= 300:
                 print("Error {} fetching status: {}".format(res.status_code, json_res))
-            elif raw:
-                return [sub for sub in json_res["submissions"] if (not active or sub["active"])]
             else:
                 if not verbose:
                     print()  # Newline, because non-verbose won't include one

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mdf_connect_client',
-    version='0.2.1',
+    version='0.3.0',
     packages=['mdf_connect_client'],
     description='Materials Data Facility Connect Client',
     long_description=("The MDF Connect Client is the Python client to easily submit"


### PR DESCRIPTION
Improvements for the MDF Connect website and submission form.

The return value of both `check_status()` and `check_all_submissions()` when `raw=True` is set has been changed. The return value is now always a dictionary, essentially the same response as from the MDF Connect API (with `success` and `error` keys, etc., plus a `status_code` key). I don't believe any code currently relies on the old (and unfortunately inconsistent) behavior, so these changes should be transparent for all current users.

The version is getting a bump up to 0.3.0 to reflect the technically backwards-incompatible modifications.