### PR TITLE
Update dev URL to point to AWS Gateway

### DIFF
--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -9,7 +9,7 @@ import requests
 from .version import __version__
 
 CONNECT_SERVICE_LOC = "https://api.materialsdatafacility.org"
-CONNECT_DEV_LOC = "https://dev-api.materialsdatafacility.org"
+CONNECT_DEV_LOC = "https://f6avec0img.execute-api.us-east-1.amazonaws.com/test"
 CONNECT_EXTRACT_ROUTE = "/submit"
 CONNECT_STATUS_ROUTE = "/status/"
 CONNECT_ALL_STATUS_ROUTE = "/submissions/"


### PR DESCRIPTION
# Problem
The URL for MDF Connect has changed for the dev instance while we are developing the serverless architecture

# Approach 
Update the URL in the library for dev only