### PR TITLE
update mdf-toolbox to 0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=("The MDF Connect Client is the Python client to easily submit"
                       " datasets to MDF Connect."),
     install_requires=[
-        "mdf-toolbox>=0.5.0",
+        "mdf-toolbox>=0.6.0",
         "nameparser>=1.0.4",
         "requests>=2.18.4"
     ],


### PR DESCRIPTION
mdf-toolbox < 0.6.0 uses `http_timeout` incorrectly with Globus Auth