### PR TITLE
Prepare for MDF 2.0 release 

### DIFF
--- a/.github/workflows/testing-work.yml
+++ b/.github/workflows/testing-work.yml
@@ -30,10 +30,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
-          pip install pytest-cov
           pip install -e .
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install -r test_requirements.txt
 
       - name: Test with pytest
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 *.swo
 *login*
 *.ipynb_checkpoints
+.venv
 Untitled*.ipynb
-
+.idea
 *.cache*
 *pytest_cache*
 

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -967,16 +967,16 @@ class MDFConnectClient:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
-            if "status" not in json_res['flow_status']:
+            if 'status' not in json_res['flow_status']:
                 print("Error: No status found for this submission.")
                 return json_res
 
-            if json_res["status"] == 'ACTIVE':
+            if json_res['flow_status']['status'] == 'ACTIVE':
                 active_msg = "This submission is still processing."
             else:
                 active_msg = "This submission is no longer processing."
             if raw:
-                json_res["status_code"] = res.status_code
+                json_res['flow_status']['status_code'] = res.status_code
                 return json_res
             elif res.status_code >= 300:
                 print("Error {} fetching status: {}".format(res.status_code,

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -13,7 +13,7 @@ CONNECT_DEV_LOC = "https://6oqmi1rtp2.execute-api.us-east-1.amazonaws.com/test"
 
 CONNECT_EXTRACT_ROUTE = "/submit"
 CONNECT_STATUS_ROUTE = "/status/"
-CONNECT_ALL_STATUS_ROUTE = "/submissions/"
+CONNECT_ALL_STATUS_ROUTE = "/submissions"
 CONNECT_CURATION_ROUTE = "/curate/"
 CONNECT_ALL_CURATION_ROUTE = "/curation/"
 CONNECT_MD_UPDATE_ROUTE = "/update/"

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -399,24 +399,19 @@ class MDFConnectClient:
         """
         self.test = test
 
-    def add_organization(self, organization):
-        """Add your dataset to an organization.
+    def set_organization(self, organization):
+        """Set the organization that governs the dataset.
 
         Arguments:
-            organization (str or list of str): The organization(s) to add.
+            organization (str): The organization to add.
                     If the organization is not registered with MDF, it will be discarded.
-                    Parent organizations will be added automatically.
         """
-        if not isinstance(organization, list):
-            organization = [organization]
-        if not self.mdf.get("organizations"):
-            self.mdf["organizations"] = organization
-        else:
-            self.mdf["organizations"].extend(organization)
 
-    def clear_organizations(self):
-        """Clear all added organizations from the submission."""
-        self.mdf.pop("organizations", None)
+        self.mdf["organization"] = organization
+
+    def clear_organization(self):
+        """Clear the added organizations from the submission."""
+        self.mdf.pop("organization", None)
 
     def add_links(self, links):
         """Add links to a dataset.

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -971,7 +971,7 @@ class MDFConnectClient:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
-            if json_res.get("status", {}).get("active"):
+            if json_res["status"] == 'ACTIVE':
                 active_msg = "This submission is still processing."
             else:
                 active_msg = "This submission is no longer processing."
@@ -984,7 +984,7 @@ class MDFConnectClient:
             elif short:
                 print("{}: {}".format((source_id or self.source_id), active_msg))
             else:
-                print("\n{}\n{}\n".format(json_res["status"]["status_message"], active_msg))
+                print("\n{}\n{}\n".format(json_res["display_status"], active_msg))
 
     def check_all_submissions(self, verbose=False, active_only=False, include_tests=True,
                               newer_than_date=None, older_than_date=None, raw=False,

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -9,7 +9,7 @@ import requests
 from .version import __version__
 
 CONNECT_SERVICE_LOC = "https://publish-prod.materialsdatafacility.org"
-CONNECT_DEV_LOC = "https://6oqmi1rtp2.execute-api.us-east-1.amazonaws.com/test"
+CONNECT_DEV_LOC = "https://publish-dev.materialsdatafacility.org"
 
 CONNECT_EXTRACT_ROUTE = "/submit"
 CONNECT_STATUS_ROUTE = "/status/"

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -967,6 +967,11 @@ class MDFConnectClient:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
+            if "status" not in json_res:
+                print("Error: No status found for this submission.")
+                print(json_res)
+                return None
+
             if json_res["status"] == 'ACTIVE':
                 active_msg = "This submission is still processing."
             else:

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -667,6 +667,8 @@ class MDFConnectClient:
         }
         if self.mdf:
             submission["mdf"] = self.mdf
+        else:
+            submission["mdf"] = {}
         if self.mrr:
             submission["mrr"] = self.mrr
         if self.custom:

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -528,7 +528,7 @@ class MDFConnectClient:
         """Remove a previously set source_name."""
         self.mdf.pop("source_name", None)
 
-    def set_update_metadata_only(self, meta_only):
+    def set_update_metadata_only(self, metadata_only):
         """Make this submission an update on the metadata only of a previous submission.
         Incremental updates use the same submission metadata, except for whatever you
         specify in the new submission. For example, if you submit an metadata only update
@@ -539,9 +539,9 @@ class MDFConnectClient:
             You must still set ``update=True`` when submitting an incremental update.
 
         Arguments:
-            meta_only (boolean): If true then flow performs an update on the metadata only
+            metadata_only (boolean): If true then flow performs an update on the metadata only
         """
-        self.update_meta_only = meta_only
+        self.update_metadata_only = metadata_only
 
     def add_data_destination(self, data_destination):
         """Add a data destination to your submission.
@@ -695,7 +695,7 @@ class MDFConnectClient:
             submission["no_extract"] = self.no_extract
         if self.dataset_acl:
             submission["dataset_acl"] = self.dataset_acl
-        submission["update_meta_only"] = self.update_meta_only
+        submission["update_metadata_only"] = self.update_metadata_only
         return submission
 
     def reset_submission(self):
@@ -783,7 +783,7 @@ class MDFConnectClient:
 
         # Check for required data
         if ((not submission["dc"] or not submission["data_sources"])
-                and not submission["update_meta_only"]):
+                and not submission["update_metadata_only"]):
             return {
                 'source_id': None,
                 'success': False,
@@ -868,7 +868,7 @@ class MDFConnectClient:
         metadata_update.pop("services", None)
         metadata_update.pop("curation", None)
         metadata_update.pop("no_extract", None)
-        metadata_update.pop("update_meta_only", None)
+        metadata_update.pop("update_metadata_only", None)
 
         # Validate JSON
         try:

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -8,8 +8,9 @@ import requests
 
 from .version import __version__
 
-CONNECT_SERVICE_LOC = "https://publish.materialsdatafacility.org"
-CONNECT_DEV_LOC = "https://publish-dev.materialsdatafacility.org"
+CONNECT_SERVICE_LOC = "https://publish-prod.materialsdatafacility.org"
+CONNECT_DEV_LOC = "https://6oqmi1rtp2.execute-api.us-east-1.amazonaws.com/test"
+
 CONNECT_EXTRACT_ROUTE = "/submit"
 CONNECT_STATUS_ROUTE = "/status/"
 CONNECT_ALL_STATUS_ROUTE = "/submissions/"

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -967,10 +967,9 @@ class MDFConnectClient:
                 print("Error {}. MDF Connect may be experiencing technical"
                       " difficulties.".format(res.status_code))
         else:
-            if "status" not in json_res:
+            if "status" not in json_res['flow_status']:
                 print("Error: No status found for this submission.")
-                print(json_res)
-                return None
+                return json_res
 
             if json_res["status"] == 'ACTIVE':
                 active_msg = "This submission is still processing."

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -8,8 +8,8 @@ import requests
 
 from .version import __version__
 
-CONNECT_SERVICE_LOC = "https://api.materialsdatafacility.org"
-CONNECT_DEV_LOC = "https://f6avec0img.execute-api.us-east-1.amazonaws.com/test"
+CONNECT_SERVICE_LOC = "https://publish.materialsdatafacility.org"
+CONNECT_DEV_LOC = "https://publish-dev.materialsdatafacility.org"
 CONNECT_EXTRACT_ROUTE = "/submit"
 CONNECT_STATUS_ROUTE = "/status/"
 CONNECT_ALL_STATUS_ROUTE = "/submissions/"

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -528,7 +528,7 @@ class MDFConnectClient:
         """Remove a previously set source_name."""
         self.mdf.pop("source_name", None)
 
-    def set_incremental_update(self, source_id):
+    def set_update_metadata_only(self, meta_only):
         """Make this submission an incremental update of a previous submission.
         Incremental updates use the same submission metadata, except for whatever you
         specify in the new submission. For example, if you submit an incremental update
@@ -539,9 +539,9 @@ class MDFConnectClient:
             You must still set ``update=True`` when submitting an incremental update.
 
         Arguments:
-            source_id (str): The ``source_id`` of the previous submission to update.
+            meta_only (boolean): The ``source_id`` of the previous submission to update.
         """
-        self.incremental_update = source_id
+        self.update_meta_only = meta_only
 
     def add_data_destination(self, data_destination):
         """Add a data destination to your submission.
@@ -695,8 +695,8 @@ class MDFConnectClient:
             submission["no_extract"] = self.no_extract
         if self.dataset_acl:
             submission["dataset_acl"] = self.dataset_acl
-        if self.incremental_update:
-            submission["incremental_update"] = self.incremental_update
+        if self.update_meta_only:
+            submission["update_meta_only"] = self.update_meta_only
         return submission
 
     def reset_submission(self):
@@ -723,7 +723,7 @@ class MDFConnectClient:
         self.set_extraction_config({})
         self.set_curation(False)
         self.set_passthrough(False)
-        self.set_incremental_update(False)
+        self.set_update_metadata_only(False)
 
         self.clear_data_sources()
         self.clear_external_uri()
@@ -784,7 +784,7 @@ class MDFConnectClient:
 
         # Check for required data
         if ((not submission["dc"] or not submission["data_sources"])
-                and not submission["incremental_update"]):
+                and not submission["update_meta_only"]):
             return {
                 'source_id': None,
                 'success': False,
@@ -869,7 +869,7 @@ class MDFConnectClient:
         metadata_update.pop("services", None)
         metadata_update.pop("curation", None)
         metadata_update.pop("no_extract", None)
-        metadata_update.pop("incremental_update", None)
+        metadata_update.pop("update_meta_only", None)
 
         # Validate JSON
         try:

--- a/mdf_connect_client/mdfcc.py
+++ b/mdf_connect_client/mdfcc.py
@@ -529,9 +529,9 @@ class MDFConnectClient:
         self.mdf.pop("source_name", None)
 
     def set_update_metadata_only(self, meta_only):
-        """Make this submission an incremental update of a previous submission.
+        """Make this submission an update on the metadata only of a previous submission.
         Incremental updates use the same submission metadata, except for whatever you
-        specify in the new submission. For example, if you submit an incremental update
+        specify in the new submission. For example, if you submit an metadata only update
         and only include a ``data_source``, the submission will run as if you copied the
         DC block and other metadata into the submission, but with the new ``data_source``.
 
@@ -539,7 +539,7 @@ class MDFConnectClient:
             You must still set ``update=True`` when submitting an incremental update.
 
         Arguments:
-            meta_only (boolean): The ``source_id`` of the previous submission to update.
+            meta_only (boolean): If true then flow performs an update on the metadata only
         """
         self.update_meta_only = meta_only
 
@@ -695,8 +695,7 @@ class MDFConnectClient:
             submission["no_extract"] = self.no_extract
         if self.dataset_acl:
             submission["dataset_acl"] = self.dataset_acl
-        if self.update_meta_only:
-            submission["update_meta_only"] = self.update_meta_only
+        submission["update_meta_only"] = self.update_meta_only
         return submission
 
     def reset_submission(self):

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-alpha.4"
+__version__ = "0.5.0-rc.1"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.4.1"
+__version__ = "0.5.0-alpha.2"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-rc.4"
+__version__ = "0.5.0"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-alpha.2"
+__version__ = "0.5.0-alpha.3"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-alpha.3"
+__version__ = "0.5.0-alpha.4"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-rc.2"
+__version__ = "0.5.0-rc.4"

--- a/mdf_connect_client/version.py
+++ b/mdf_connect_client/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.5.0-rc.1"
+__version__ = "0.5.0-rc.2"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=("The MDF Connect Client is the Python client to easily submit"
                       " datasets to MDF Connect."),
     install_requires=[
-        "mdf-toolbox==0.6.1-alpha.1",
+        "mdf-toolbox==0.7.0-rc.1",
         "nameparser>=1.0.4",
         "requests>=2.18.4"
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=("The MDF Connect Client is the Python client to easily submit"
                       " datasets to MDF Connect."),
     install_requires=[
-        "mdf-toolbox>=0.6.0",
+        "mdf-toolbox==0.6.1-alpha.1",
         "nameparser>=1.0.4",
         "requests>=2.18.4"
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description=("The MDF Connect Client is the Python client to easily submit"
                       " datasets to MDF Connect."),
     install_requires=[
-        "mdf-toolbox==0.7.0-rc.1",
+        "mdf-toolbox>=0.7.1",
         "nameparser>=1.0.4",
         "requests>=2.18.4"
     ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,5 @@ coveralls>=1.10.0
 nbval>=0.9.4
 pytest>=5.3.1
 pytest-cov>=2.5.1
+pytest-mock>=1.10.4
 mdf_toolbox

--- a/tests/test_connect_client.py
+++ b/tests/test_connect_client.py
@@ -1,38 +1,31 @@
 from datetime import datetime
-import os
 
 from mdf_toolbox import insensitive_comparison
-import mdf_toolbox
 import pytest
 
 from mdf_connect_client import MDFConnectClient
 from mdf_connect_client.mdfcc import CONNECT_SERVICE_LOC, CONNECT_DEV_LOC
 
-#github specific declarations
-client_id = os.getenv('CLIENT_ID')
-client_secret = os.getenv('CLIENT_SECRET')
 
-auths = mdf_toolbox.confidential_login(client_id=client_id,
-                                        client_secret=client_secret,
-                                        services=["mdf_connect", "mdf_connect_dev"],
-                                        make_clients=True)
+@pytest.fixture
+def auths(mocker):
+    return {"mdf_connect": mocker.MagicMock(), "mdf_connect_dev": mocker.MagicMock()}
 
-print(auths)
 
-def test_service_loc():
-    mdf1 = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_service_loc(auths):
+    mdf1 = MDFConnectClient(authorizer=auths["mdf_connect"])
     assert mdf1.service_loc == CONNECT_SERVICE_LOC
-    mdf2 = MDFConnectClient(service_instance="prod", authorizer=auths['mdf_connect'])
+    mdf2 = MDFConnectClient(service_instance="prod", authorizer=auths["mdf_connect"])
     assert mdf2.service_loc == CONNECT_SERVICE_LOC
-    mdf3 = MDFConnectClient(service_instance="dev", authorizer=auths['mdf_connect_dev'])
+    mdf3 = MDFConnectClient(service_instance="dev", authorizer=auths["mdf_connect_dev"])
     assert mdf3.service_loc == CONNECT_DEV_LOC
 
     with pytest.raises(ValueError):
-        MDFConnectClient(service_instance="foobar", authorizer=auths['mdf_connect'])
+        MDFConnectClient(service_instance="foobar", authorizer=auths["mdf_connect"])
 
 
-def test_create_dc_block():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_create_dc_block(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     # Full test, no lists
     mdf.create_dc_block(
         title="Connect Title",
@@ -45,41 +38,32 @@ def test_create_dc_block():
         dataset_doi="10.555",
         related_dois="10.5555",
         subjects="Science",
-        other=5
+        other=5,
     )
     assert mdf.dc == {
-        'creators': [{
-            'affiliations': ['UChicago'],
-            'creatorName': 'Data Facility, Materials',
-            'familyName': 'Data Facility',
-            'givenName': 'Materials'
-        }],
-        'descriptions': [{
-            'description': 'This is a test',
-            'descriptionType': 'Other'
-        }],
-        'identifier': {
-            'identifier': '10.555',
-            'identifierType': 'DOI'
-        },
-        'other': 5,
-        'publicationYear': '2017',
-        'publisher': 'Globus',
-        'relatedIdentifiers': [{
-            'relatedIdentifier': '10.5555',
-            'relatedIdentifierType': 'DOI',
-            'relationType': 'IsPartOf'
-        }],
-        'resourceType': {
-            'resourceType': 'Dataset',
-            'resourceTypeGeneral': 'Dataset'
-        },
-        'titles': [{
-            'title': 'Connect Title'
-        }],
-        'subjects': [{
-            'subject': 'Science'
-        }]
+        "creators": [
+            {
+                "affiliations": ["UChicago"],
+                "creatorName": "Data Facility, Materials",
+                "familyName": "Data Facility",
+                "givenName": "Materials",
+            }
+        ],
+        "descriptions": [{"description": "This is a test", "descriptionType": "Other"}],
+        "identifier": {"identifier": "10.555", "identifierType": "DOI"},
+        "other": 5,
+        "publicationYear": "2017",
+        "publisher": "Globus",
+        "relatedIdentifiers": [
+            {
+                "relatedIdentifier": "10.5555",
+                "relatedIdentifierType": "DOI",
+                "relationType": "IsPartOf",
+            }
+        ],
+        "resourceType": {"resourceType": "Dataset", "resourceTypeGeneral": "Dataset"},
+        "titles": [{"title": "Connect Title"}],
+        "subjects": [{"subject": "Science"}],
     }
     # Full test, all lists
     mdf.create_dc_block(
@@ -94,109 +78,83 @@ def test_create_dc_block():
         related_dois=["10.5555", "10.555-5555"],
         subjects=["Science", "Math"],
         other=5,
-        list_other=["a", "b"]
+        list_other=["a", "b"],
     )
     assert mdf.dc == {
-        'creators': [{
-                'affiliations': ['UChicago', 'Argonne'],
-                'creatorName': 'Data Facility, Materials',
-                'familyName': 'Data Facility',
-                'givenName': 'Materials'
+        "creators": [
+            {
+                "affiliations": ["UChicago", "Argonne"],
+                "creatorName": "Data Facility, Materials",
+                "familyName": "Data Facility",
+                "givenName": "Materials",
             },
             {
-                'affiliations': ['UChicago', 'Argonne'],
-                'creatorName': 'Blaiszik, Ben',
-                'familyName': 'Blaiszik',
-                'givenName': 'Ben'
+                "affiliations": ["UChicago", "Argonne"],
+                "creatorName": "Blaiszik, Ben",
+                "familyName": "Blaiszik",
+                "givenName": "Ben",
             },
             {
-                'affiliations': ['UChicago', 'Argonne'],
-                'creatorName': 'Gaff, Jonathon',
-                'familyName': 'Gaff',
-                'givenName': 'Jonathon'
-            }
+                "affiliations": ["UChicago", "Argonne"],
+                "creatorName": "Gaff, Jonathon",
+                "familyName": "Gaff",
+                "givenName": "Jonathon",
+            },
         ],
-        'descriptions': [{
-            'description': 'This is a test',
-            'descriptionType': 'Other'
-        }],
-        'identifier': {
-            'identifier': '10.555',
-            'identifierType': 'DOI'
-        },
-        'list_other': ['a', 'b'],
-        'other': 5,
-        'publicationYear': '2017',
-        'publisher': 'Globus',
-        'relatedIdentifiers': [{
-                'relatedIdentifier': '10.5555',
-                'relatedIdentifierType': 'DOI',
-                'relationType': 'IsPartOf'
+        "descriptions": [{"description": "This is a test", "descriptionType": "Other"}],
+        "identifier": {"identifier": "10.555", "identifierType": "DOI"},
+        "list_other": ["a", "b"],
+        "other": 5,
+        "publicationYear": "2017",
+        "publisher": "Globus",
+        "relatedIdentifiers": [
+            {
+                "relatedIdentifier": "10.5555",
+                "relatedIdentifierType": "DOI",
+                "relationType": "IsPartOf",
             },
             {
-                'relatedIdentifier': '10.555-5555',
-                'relatedIdentifierType': 'DOI',
-                'relationType': 'IsPartOf'
-            }
+                "relatedIdentifier": "10.555-5555",
+                "relatedIdentifierType": "DOI",
+                "relationType": "IsPartOf",
+            },
         ],
-        'resourceType': {
-            'resourceType': 'Dataset',
-            'resourceTypeGeneral': 'Dataset'
-        },
-        'titles': [{
-            'title': 'Connect Title'
-        }, {
-            'title': 'Other Title'
-        }],
-        'subjects': [{
-            'subject': 'Science'
-        }, {
-            'subject': 'Math'
-        }]
+        "resourceType": {"resourceType": "Dataset", "resourceTypeGeneral": "Dataset"},
+        "titles": [{"title": "Connect Title"}, {"title": "Other Title"}],
+        "subjects": [{"subject": "Science"}, {"subject": "Math"}],
     }
     # Minimum test
     mdf.create_dc_block(
-        title="Project One",
-        authors=["Artemis Moonshot", "Landing, Apollo"]
+        title="Project One", authors=["Artemis Moonshot", "Landing, Apollo"]
     )
     assert mdf.dc == {
-        'creators': [{
-                'creatorName': 'Moonshot, Artemis',
-                'familyName': 'Moonshot',
-                'givenName': 'Artemis'
+        "creators": [
+            {
+                "creatorName": "Moonshot, Artemis",
+                "familyName": "Moonshot",
+                "givenName": "Artemis",
             },
             {
-                'creatorName': 'Landing, Apollo',
-                'familyName': 'Landing',
-                'givenName': 'Apollo'
-            }
+                "creatorName": "Landing, Apollo",
+                "familyName": "Landing",
+                "givenName": "Apollo",
+            },
         ],
-        'publicationYear': str(datetime.now().year),
-        'publisher': 'Materials Data Facility',
-        'resourceType': {
-            'resourceType': 'Dataset',
-            'resourceTypeGeneral': 'Dataset'
-        },
-        'titles': [{
-            'title': 'Project One'
-        }]
+        "publicationYear": str(datetime.now().year),
+        "publisher": "Materials Data Facility",
+        "resourceType": {"resourceType": "Dataset", "resourceTypeGeneral": "Dataset"},
+        "titles": [{"title": "Project One"}],
     }
 
 
-def test_acl():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_acl(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_base_acl("12345abc")
-    assert mdf.mdf == {
-        "acl": ["12345abc"]
-    }
+    assert mdf.mdf == {"acl": ["12345abc"]}
     mdf.set_base_acl(["12345abc", "6789def"])
-    assert mdf.mdf == {
-        "acl": ["12345abc", "6789def"]
-    }
+    assert mdf.mdf == {"acl": ["12345abc", "6789def"]}
     mdf.set_base_acl("public")
-    assert mdf.mdf == {
-        "acl": ["public"]
-    }
+    assert mdf.mdf == {"acl": ["public"]}
     mdf.clear_base_acl()
     assert mdf.mdf.get("acl", None) is None
 
@@ -210,37 +168,29 @@ def test_acl():
     assert mdf.dataset_acl is None
 
 
-def test_source_name():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_source_name(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_source_name("foo")
-    assert mdf.mdf == {
-        "source_name": "foo"
-    }
+    assert mdf.mdf == {"source_name": "foo"}
     mdf.clear_source_name()
     assert mdf.mdf.get("source_name", None) is None
 
 
-def test_organizations():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
-    mdf.add_organization("ANL")
-    mdf.add_organization(["ORNL", "NREL"])
-    assert mdf.mdf["organizations"] == ["ANL", "ORNL", "NREL"]
-
-    mdf.clear_organizations()
-    assert mdf.mdf.get("organizations", None) is None
-    mdf.add_organization("APS")
-    assert mdf.mdf["organizations"] == ["APS"]
+def test_organizations(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
+    mdf.set_organization("ANL")
+    assert mdf.mdf["organization"] == "ANL"
 
 
-def test_create_mrr_block():
+def test_create_mrr_block(auths):
     # TODO: Update after helper is helpful
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.create_mrr_block({"a": "b"})
     assert mdf.mrr == {"a": "b"}
 
 
-def test_set_custom_block():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_set_custom_block(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_custom_block({"foo": "bar"})
     assert mdf.custom == {"foo": "bar"}
     # OOR floats not allowed
@@ -252,25 +202,19 @@ def test_set_custom_block():
     assert mdf.custom == {}
 
 
-def test_set_custom_descriptions():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_set_custom_descriptions(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_custom_block({"foo": "bar"})
     mdf.set_custom_descriptions({"foo": "This is a foo"})
-    assert mdf.custom == {
-        "foo": "bar",
-        "foo_desc": "This is a foo"
-    }
+    assert mdf.custom == {"foo": "bar", "foo_desc": "This is a foo"}
     # OOR floats not allowed
     res = mdf.set_custom_descriptions({"foo": float("nan")})
     assert "Out of range float values are not JSON compliant" in res
-    assert mdf.custom == {
-        "foo": "bar",
-        "foo_desc": "This is a foo"
-    }
+    assert mdf.custom == {"foo": "bar", "foo_desc": "This is a foo"}
 
 
-def test_set_project_block():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_set_project_block(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_project_block("proj1", {"foo": "bar"})
     assert mdf.projects == {"proj1": {"foo": "bar"}}
     # OOR floats not allowed
@@ -282,81 +226,89 @@ def test_set_project_block():
     assert mdf.projects == {}
 
 
-def test_data():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_data(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     # data_sources
     mdf.add_data_source("https://example.com/path/data.zip")
     assert mdf.data_sources == ["https://example.com/path/data.zip"]
-    mdf.add_data_source(["https://www.globus.org/app/transfer?123",
-                         "globus://endpoint123/path/data.out"])
-    assert mdf.data_sources == ["https://example.com/path/data.zip",
-                                "https://www.globus.org/app/transfer?123",
-                                "globus://endpoint123/path/data.out"]
+    mdf.add_data_source(
+        [
+            "https://www.globus.org/app/transfer?123",
+            "globus://endpoint123/path/data.out",
+        ]
+    )
+    assert mdf.data_sources == [
+        "https://example.com/path/data.zip",
+        "https://www.globus.org/app/transfer?123",
+        "globus://endpoint123/path/data.out",
+    ]
     mdf.clear_data_sources()
     assert mdf.data_sources == []
 
     # data_destinations
     mdf.add_data_destination("https://example.com/path/data.zip")
     assert mdf.data_destinations == ["https://example.com/path/data.zip"]
-    mdf.add_data_destination(["https://www.globus.org/app/transfer?123",
-                              "globus://endpoint123/path/data.out"])
-    assert mdf.data_destinations == ["https://example.com/path/data.zip",
-                                     "https://www.globus.org/app/transfer?123",
-                                     "globus://endpoint123/path/data.out"]
+    mdf.add_data_destination(
+        [
+            "https://www.globus.org/app/transfer?123",
+            "globus://endpoint123/path/data.out",
+        ]
+    )
+    assert mdf.data_destinations == [
+        "https://example.com/path/data.zip",
+        "https://www.globus.org/app/transfer?123",
+        "globus://endpoint123/path/data.out",
+    ]
     mdf.clear_data_destinations()
     assert mdf.data_destinations == []
 
 
-def test_index():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_index(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     # Mapping only
     mdf.add_index("json", mapping={"materials.composition": "my_json.data.stuff.comp"})
     assert mdf.index == {
-        "json": {
-            "mapping": {"materials.composition": "my_json.data.stuff.comp"}
-        }
+        "json": {"mapping": {"materials.composition": "my_json.data.stuff.comp"}}
     }
     # With delim/na
-    mdf.add_index("csv", mapping={"materials.composition": "header1"},
-                  delimiter="#", na_values="zero")
+    mdf.add_index(
+        "csv",
+        mapping={"materials.composition": "header1"},
+        delimiter="#",
+        na_values="zero",
+    )
     assert mdf.index == {
-        "json": {
-            "mapping": {"materials.composition": "my_json.data.stuff.comp"}
-        },
+        "json": {"mapping": {"materials.composition": "my_json.data.stuff.comp"}},
         "csv": {
             "mapping": {"materials.composition": "header1"},
             "delimiter": "#",
-            "na_values": ["zero"]
-        }
+            "na_values": ["zero"],
+        },
     }
     # Overwrite
-    mdf.add_index("csv", mapping={"crystal_structure.space_group_number": "csv_header_2"})
+    mdf.add_index(
+        "csv", mapping={"crystal_structure.space_group_number": "csv_header_2"}
+    )
     assert mdf.index == {
-        "json": {
-            "mapping": {"materials.composition": "my_json.data.stuff.comp"}
-        },
-        "csv": {
-            "mapping": {"crystal_structure.space_group_number": "csv_header_2"}
-        }
+        "json": {"mapping": {"materials.composition": "my_json.data.stuff.comp"}},
+        "csv": {"mapping": {"crystal_structure.space_group_number": "csv_header_2"}},
     }
     # Bad input
-    res = mdf.add_index("json", mapping={"crystal_structure.space_group_number": float("nan")})
+    res = mdf.add_index(
+        "json", mapping={"crystal_structure.space_group_number": float("nan")}
+    )
     assert "Out of range float values are not JSON compliant" in res
     assert mdf.index == {
-        "json": {
-            "mapping": {"materials.composition": "my_json.data.stuff.comp"}
-        },
-        "csv": {
-            "mapping": {"crystal_structure.space_group_number": "csv_header_2"}
-        }
+        "json": {"mapping": {"materials.composition": "my_json.data.stuff.comp"}},
+        "csv": {"mapping": {"crystal_structure.space_group_number": "csv_header_2"}},
     }
     # Clear
     mdf.clear_index()
     assert mdf.index == {}
 
 
-def test_extraction_config():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_extraction_config(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.set_extraction_config({"group_by_dir": True})
     assert mdf.extraction_config == {"group_by_dir": True}
     # OOR floats not allowed
@@ -368,36 +320,24 @@ def test_extraction_config():
     assert mdf.extraction_config == {}
 
 
-def test_services():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_services(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     # No parameters
     mdf.add_service("citrine")
-    assert mdf.services == {
-        "citrine": True
-    }
+    assert mdf.services == {"citrine": True}
     # With parameters
     mdf.add_service("globus_publish", parameters={"collection_id": 5555})
-    assert mdf.services == {
-        "citrine": True,
-        "globus_publish": {
-            "collection_id": 5555
-        }
-    }
+    assert mdf.services == {"citrine": True, "globus_publish": {"collection_id": 5555}}
     # Cancelling
     mdf.add_service("citrine", False)
-    assert mdf.services == {
-        "citrine": False,
-        "globus_publish": {
-            "collection_id": 5555
-        }
-    }
+    assert mdf.services == {"citrine": False, "globus_publish": {"collection_id": 5555}}
     # Removing
     mdf.clear_services()
     assert mdf.services == {}
 
 
-def test_tags():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_tags(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     mdf.add_tag("foo")
     assert mdf.tags == ["foo"]
     mdf.add_tag(["bar", "baz"])
@@ -406,8 +346,8 @@ def test_tags():
     assert mdf.tags == []
 
 
-def test_curation():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_curation(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     assert mdf.curation is False
     mdf.set_curation(True)
     assert mdf.curation is True
@@ -415,19 +355,19 @@ def test_curation():
     assert mdf.curation is False
 
 
-def test_set_test():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_set_test(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     assert mdf.test is False
     mdf.set_test(True)
     assert mdf.test is True
     mdf.set_test(False)
     assert mdf.test is False
-    mdf2 = MDFConnectClient(test=True, authorizer=auths['mdf_connect'])
+    mdf2 = MDFConnectClient(test=True, authorizer=auths["mdf_connect"])
     assert mdf2.test is True
 
 
-def test_passthrough():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
+def test_passthrough(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
     assert mdf.no_extract is False
     mdf.set_passthrough(True)
     assert mdf.no_extract is True
@@ -435,38 +375,48 @@ def test_passthrough():
     assert mdf.no_extract is False
 
 
-def test_submission():
-    mdf = MDFConnectClient(authorizer=auths['mdf_connect'])
-    assert insensitive_comparison(mdf.get_submission(),
-                                  {"dc": {},
-                                   "data_sources": [],
-                                   "test": False,
-                                   "update": False})
+def test_submission(auths):
+    mdf = MDFConnectClient(authorizer=auths["mdf_connect"])
+    assert insensitive_comparison(
+        mdf.get_submission(),
+        {
+            "dc": {},
+            "data_sources": [],
+            "mdf": {},
+            "test": False,
+            "update": False,
+            "update_metadata_only": False,
+        },
+    )
     mdf.dc = {"a": "a"}
     mdf.mdf = {"b": "b"}
     mdf.services = {"c": "c"}
     mdf.projects = {"foo": {"bar": "baz"}}
-    assert insensitive_comparison(mdf.get_submission(),
-                                  {"dc": {"a": "a"},
-                                   "mdf": {"b": "b"},
-                                   "projects": {"foo": {"bar": "baz"}},
-                                   "services": {"c": "c"},
-                                   "data_sources": [],
-                                   "test": False,
-                                   "update": False})
+    assert insensitive_comparison(
+        mdf.get_submission(),
+        {
+            "dc": {"a": "a"},
+            "mdf": {"b": "b"},
+            "projects": {"foo": {"bar": "baz"}},
+            "services": {"c": "c"},
+            "data_sources": [],
+            "test": False,
+            "update": False,
+            "update_metadata_only": False,
+        },
+    )
+
     mdf.reset_submission()
-    assert insensitive_comparison(mdf.get_submission(),
-                                  {"dc": {},
-                                   "data_sources": [],
-                                   "test": False,
-                                   "update": False})
+    assert insensitive_comparison(
+        mdf.get_submission(),
+        {"dc": {}, "mdf": {}, "data_sources": [], "test": False, "update": False, "update_metadata_only": False},
+    )
     mdf.set_test(True)
     mdf.reset_submission()
-    assert insensitive_comparison(mdf.get_submission(),
-                                  {"dc": {},
-                                   "data_sources": [],
-                                   "test": True,
-                                   "update": False})
+    assert insensitive_comparison(
+        mdf.get_submission(),
+        {"dc": {}, "mdf": {},"data_sources": [], "test": True, "update": False, "update_metadata_only": False},
+    )
 
 
 # def test_submit_dataset():

--- a/tests/test_connect_client.py
+++ b/tests/test_connect_client.py
@@ -5,11 +5,11 @@ import pytest
 
 from mdf_connect_client import MDFConnectClient
 from mdf_connect_client.mdfcc import CONNECT_SERVICE_LOC, CONNECT_DEV_LOC
-
+from globus_sdk import NullAuthorizer
 
 @pytest.fixture
 def auths(mocker):
-    return {"mdf_connect": mocker.MagicMock(), "mdf_connect_dev": mocker.MagicMock()}
+    return {"mdf_connect": NullAuthorizer(), "mdf_connect_dev": NullAuthorizer()}
 
 
 def test_service_loc(auths):


### PR DESCRIPTION
This change accompanies the release of the serverless MDF Connect "server". 

In addition to picking up the new mdf REST endpoint URLs and new toolkit library, there are some usability changes.

1. There is now only one organization for a submission (so add_organization became set_organization)
2. Incremental update was confusing, so now it is called update_metadata_only